### PR TITLE
npm test => make test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description":"mongoose plugin to create maintain one-many and many-many bidirectional relationships between two schemas",
     "main":"index.js",
     "scripts": {
-        "test":"mocha"
+        "test":"make test"
     },
     "keywords": [
         "mongoose",


### PR DESCRIPTION
Since there is a `Makefile` with config for testing, it makes sense to specify this in `package.json`.

The `Makefile` sets the mocha spec reporter, which I agree is much more readable than the dots. Still not sure why dots is default?!? Might as well take advantage of the better reporter with `npm test` too.

Might also want to update the README accordingly?
